### PR TITLE
Minor readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To not show the whole post but only the first bit and then `read more ...`, use 
 
 To set up a development environment: in a new conda env or virtualenv:
 ```
-$ pip install nikola[extras]
+$ pip install "nikola[extras]"
 $ nikola theme -i maupassant
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ $ nikola theme -i maupassant
 
 Configuration file for the site is ``conf.py``.
 
-To build the site::
+To build the site:
 
     nikola build
 
-To see it::
+To see it:
 
     nikola serve -b
 
-To check all available commands::
+To check all available commands:
 
     nikola help
 
 ## Deployment
 
-Submit pull requests first, those get run on CircleCI where the new site can be checked (stored in `Artifacts`). On merge the site will get deployed to labs.quansight.org
+Submit pull requests first, those get run on CircleCI where the new site can be checked (stored in `Artifacts`). On merge the site will get deployed to https://labs.quansight.org


### PR DESCRIPTION
This PR has a few very minor updates to the README:

- Adds quotes to `pip install nikola[extras]`, which can fail on some shells (e.g. zsh) that use square brackets for pattern matching

- Adds "https://" to labs.quansight.org, so the link is rendered

- Removes a few redundant ":"