### PR TITLE
PR: Add non-blog config and some initial pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -69,16 +69,10 @@ TRANSLATIONS_PATTERN = '{path}.{lang}.{ext}'
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
         ("/", "Home"),
-        (
-            (
-                ("/blog", "Blog Index"),
-                ("/archive.html", "Archive"),
-            ),
-            "Blog"
-        ),
+        ("/blog/", "Blog"),
         ("/rss.xml", "Team"),
         ("/categories/", "Projects"),
-        ("/about", "About"),
+        ("/about/", "About"),
     ),
 }
 

--- a/conf.py
+++ b/conf.py
@@ -157,12 +157,13 @@ POSTS = (
     ("posts/*.ipynb", "blog", "post_ipynb.tmpl"),
 )
 PAGES = (
-    ("pages/*.rst", "pages", "page.tmpl"),
-    ("pages/*.md", "pages", "page.tmpl"),
-    ("pages/*.html", "pages", "page.tmpl"),
-    ("pages/*.ipynb", "pages", "post_ipynb.tmpl"),
+    ("pages/*.rst", "", "page.tmpl"),
+    ("pages/*.md", "", "page.tmpl"),
+    ("pages/*.html", "", "page.tmpl"),
+    ("pages/*.ipynb", "", "post_ipynb.tmpl"),
 )
 
+INDEX_PATH = "blog"
 
 # Below this point, everything is optional
 

--- a/conf.py
+++ b/conf.py
@@ -69,7 +69,13 @@ TRANSLATIONS_PATTERN = '{path}.{lang}.{ext}'
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
         ("/", "Home"),
-        ("/archive.html", "Blog"),
+        (
+            (
+                ("/blog", "Blog Index"),
+                ("/archive.html", "Archive"),
+            ),
+            "Blog"
+        ),
         ("/rss.xml", "Team"),
         ("/categories/", "Projects"),
         ("/about", "About"),

--- a/conf.py
+++ b/conf.py
@@ -72,6 +72,7 @@ NAVIGATION_LINKS = {
         ("/archive.html", "Blog"),
         ("/rss.xml", "Team"),
         ("/categories/", "Projects"),
+        ("/about", "About"),
     ),
 }
 

--- a/pages/about.rst
+++ b/pages/about.rst
@@ -1,16 +1,16 @@
-.. title: Welcome
-.. slug: index
-.. date: 2020-01-31 12:26:47 UTC-06:00
+.. title: About
+.. slug: about
+.. date: 2020-01-31 13:50:28 UTC-06:00
 .. tags: 
-.. category: 
-.. link:
-.. description:
+.. category:
+.. link: 
+.. description: 
 .. type: text
 
 
 .. class:: jumbotron col-md-12
 
-.. image:: /images/community_landscape.png
+.. image:: /images/quansight_labs_logo.png
 
 
 .. class:: col-md-12

--- a/pages/about.rst
+++ b/pages/about.rst
@@ -10,7 +10,7 @@
 
 .. class:: jumbotron col-md-12
 
-.. image:: /images/quansight_labs_logo.png
+.. image:: /images/community_landscape.png
 
 
 .. class:: col-md-12

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -1,0 +1,27 @@
+.. title: Welcome
+.. slug: index
+.. date: 2020-01-31 12:26:47 UTC-06:00
+.. tags: 
+.. category: 
+.. link: 
+.. description: 
+.. type: text
+
+
+.. class:: jumbotron col-md-12
+
+.. image:: /images/community_landscape.png
+
+
+.. class:: col-md-12
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris non nunc turpis.
+Phasellus a ullamcorper leo. Sed fringilla dapibus orci eu ornare. Quisque
+gravida quam a mi dignissim consequat. Morbi sed iaculis mi. Vivamus ultrices
+mattis euismod. Mauris aliquet magna eget mauris volutpat a egestas leo rhoncus.
+In hac habitasse platea dictumst. Ut sed mi arcu. Nullam id massa eu orci
+convallis accumsan. Nunc faucibus sodales justo ac ornare. In eu congue eros.
+Pellentesque iaculis risus urna. Proin est lorem, scelerisque non elementum at,
+semper vel velit. Phasellus consectetur orci vel tortor tempus imperdiet. Class
+aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos
+himenaeos.

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -10,7 +10,7 @@
 
 .. class:: jumbotron col-md-12
 
-.. image:: /images/community_landscape.png
+.. image:: /images/quansight_labs_logo.png
 
 
 .. class:: col-md-12


### PR DESCRIPTION
* Enables non-blog pages along with the blog posts. 
* Adds some example pages for the main page (`Home`) and about page (`About`).
* Point Blog section of the nav bar to the Blog index page instead of the Archive.

A preview:

![web](https://user-images.githubusercontent.com/16781833/73594293-fe67db80-44da-11ea-8cde-09510cbb7f64.gif)
