### PR TITLE
Fix example 5 code

### DIFF
--- a/posts/2021/04/pytorch-tensoriterator-internals-update.md
+++ b/posts/2021/04/pytorch-tensoriterator-internals-update.md
@@ -294,9 +294,9 @@ at::Tensor self = at::randn({10, 10, 10});
 int64_t dim = 1;
 bool keepdim = false;
 
-// `make_reduction` will allocate result tensor for us, so we
-// can leave it undefined
-at::Tensor result;
+// `make_reduction` will resize result tensor for us, so we
+// can set its size to (0)
+at::Tensor result = at::empty({0}, self.options());
 
 auto iter = at::native::make_reduction(
   "sum_reduce",


### PR DESCRIPTION
Of course, the day the post goes live, one of the examples breaks. `make_reduction` no longer accepts undefined result tensors. This change is shown to fix the issue here: https://github.com/kurtamohler/pytorch-TensorIterator-examples/actions

cc @rgommers