### PR TITLE
STY Use left justify left for post index

### DIFF
--- a/themes/quansightlabs/assets/css/custom.css
+++ b/themes/quansightlabs/assets/css/custom.css
@@ -6949,9 +6949,7 @@ button.close {
 
 .postindex {
   max-width: 750px;
-  text-align: justify;
-  #margin-right: auto;
-  #margin-left: auto;
+  text-align: left;
 }
 
 div.prompt {


### PR DESCRIPTION
Using `text-align: justify` expands out the title and paragraphs to fit the width of the container:

#### On `master`

![Screen Shot 2021-05-04 at 3 15 56 PM](https://user-images.githubusercontent.com/5402633/117064545-53a12700-acf4-11eb-94ae-638ced75e824.png)

#### This `PR`

![Screen Shot 2021-05-04 at 3 15 50 PM](https://user-images.githubusercontent.com/5402633/117064560-5734ae00-acf4-11eb-840f-9156bd4f016b.png)

This is easily seen with the title for https://github.com/Quansight-Labs/quansight-labs-site/pull/184:

![Screen Shot 2021-05-04 at 4 19 07 PM](https://user-images.githubusercontent.com/5402633/117064705-86e3b600-acf4-11eb-9399-5d81387fb415.png)
