### PR TITLE
ENH Adds description into the metatags

### DIFF
--- a/pages/about.rst
+++ b/pages/about.rst
@@ -4,7 +4,8 @@
 .. tags: 
 .. category:
 .. link: 
-.. description: Us
+.. subtitle: Us
+.. description: The mission of Quansight Labs is to sustain and grow community-driven open source projects and ecosystems, with a focus on the core of the PyData stack and on tools and digital infrastructure for data science, ML/AI, and scientific computing.
 .. type: text
 
 

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -4,7 +4,8 @@
 .. tags:
 .. category:
 .. link:
-.. description: Labs
+.. subtitle: Labs
+.. description: Quansight Labs is a public-benefit division of Quansight created to provide a home for a “PyData Core Team” which consists of developers, community managers, designers, and writers who create and maintain open-source technology around all aspects of scientific and data science workflows.
 .. type: text
 
 Quansight Labs is a public-benefit division of Quansight created to provide a

--- a/pages/projects.rst
+++ b/pages/projects.rst
@@ -4,7 +4,8 @@
 .. tags: 
 .. category: 
 .. link: 
-.. description: Projects
+.. subtitle: Projects
+.. description: See Our Projects we are actively working on
 .. type: text
 
 

--- a/pages/team.rst
+++ b/pages/team.rst
@@ -4,7 +4,8 @@
 .. tags: 
 .. category: 
 .. link: 
-.. description: Team
+.. subtitle: Team
+.. description: Meet Our Team
 .. type: text
 
 .. gallery:: team gallery_directive_team.tmpl

--- a/themes/quansightlabs/templates/post_header.tmpl
+++ b/themes/quansightlabs/templates/post_header.tmpl
@@ -4,10 +4,10 @@
 
 <%def name="html_title()">
 %if title and not post.meta('hidetitle'):
-    %if description :
+    %if post.meta('subtitle') :
             <div class="sub-header">
                 <h1>
-                    ${post.title()|h}<span class="sub-title"> ${post.description()|h}</span>
+                    ${post.title()|h}<span class="sub-title"> ${post.meta('subtitle')|h}</span>
                 </h1>
                 <div class="sub-underline"> </div>
             </div>

--- a/themes/quansightlabs/templates/post_ipynb.tmpl
+++ b/themes/quansightlabs/templates/post_ipynb.tmpl
@@ -12,6 +12,7 @@
     <meta name="keywords" content="${smartjoin(', ', post.meta('keywords'))|h}">
     % endif
     <meta name="author" content="${post.author()|h}">
+    <meta property="description" content="${post.text(strip_html=True)[:200]|h}">
     %if post.prev_post:
         <link rel="prev" href="${post.prev_post.permalink()}" title="${post.prev_post.title()|h}" type="text/html">
     %endif


### PR DESCRIPTION
While looking at https://github.com/Quansight-Labs/quansight-labs-site/pull/200, I saw that the description was either non-descriptive or not present in the description metatag. This PR adds the description into the metatags.