### PR TITLE
add blog post for `pytest-pytorch`

### DIFF
--- a/posts/2021/06/pytest-pytorch.ipynb
+++ b/posts/2021/06/pytest-pytorch.ipynb
@@ -176,6 +176,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e01f6a20-6871-48fa-a031-3fa25909212e",
+   "metadata": {},
+   "source": [
+    "<!-- TEASER_END -->"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "f266cfce-5341-4f19-92fe-31221ca7e282",
@@ -228,14 +236,6 @@
     "\n",
     "[`pytest`]: https://pytest.org\n",
     "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a4a96448",
-   "metadata": {},
-   "source": [
-    "<!-- TEASER_END -->"
    ]
   },
   {

--- a/posts/2021/06/pytest-pytorch.ipynb
+++ b/posts/2021/06/pytest-pytorch.ipynb
@@ -894,7 +894,7 @@
   },
   "nikola": {
    "author": "Philip Meier",
-   "date": "2021-06-21 11:35:06 UTC",
+   "date": "2021-06-23 18:35:06 UTC",
    "slug": "pytest-pytorch",
    "title": "Working with pytest on PyTorch"
   }

--- a/posts/2021/06/pytest-pytorch.ipynb
+++ b/posts/2021/06/pytest-pytorch.ipynb
@@ -109,8 +109,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR: not found: /home/user/tmp2evnfl00.py::TestFoo::test_bar\n",
-      "(no name '/home/user/tmp2evnfl00.py::TestFoo::test_bar' in any of [<Module tmp2evnfl00.py>])\n",
+      "ERROR: not found: /home/user/tmp35zsok9u.py::TestFoo::test_bar\n",
+      "(no name '/home/user/tmp35zsok9u.py::TestFoo::test_bar' in any of [<Module tmp35zsok9u.py>])\n",
       "\n"
      ]
     }
@@ -195,9 +195,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "F                                                                                                                                                     [100%]\n",
-      "========================================================================= FAILURES ==========================================================================\n",
-      "__________________________________________________________________ TestFooCPU.test_bar_cpu __________________________________________________________________\n",
+      "F                                                                        [100%]\n",
+      "=================================== FAILURES ===================================\n",
+      "___________________________ TestFooCPU.test_bar_cpu ____________________________\n",
       "\n",
       "self = <__main__.TestFooCPU testMethod=test_bar_cpu>, device = 'cpu'\n",
       "\n",
@@ -207,9 +207,9 @@
       "E       assert False\n",
       "\n",
       "<ipython-input-2-f22a5e9e7b30>:7: AssertionError\n",
-      "================================================================== short test summary info ==================================================================\n",
-      "FAILED tmpaklzvmu7.py::TestFooCPU::test_bar_cpu - AssertionError: Don't worry, this is supposed to happen!\n",
-      "1 failed, 1 warning in 0.18s\n"
+      "=========================== short test summary info ============================\n",
+      "FAILED tmpt8c1r46_.py::TestFooCPU::test_bar_cpu - AssertionError: Don't worry...\n",
+      "1 failed, 1 warning in 0.17s\n"
      ]
     }
    ],
@@ -273,10 +273,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp8ai3jsyh.py::TestFoo::test_bar\n",
-      "tmp8ai3jsyh.py::TestFoo::test_baz\n",
+      "tmpy90fpw2t.py::TestFoo::test_bar\n",
+      "tmpy90fpw2t.py::TestFoo::test_baz\n",
       "\n",
-      "2 tests collected in 0.03s\n"
+      "2 tests collected in 0.04s\n"
      ]
     }
    ],
@@ -316,10 +316,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp3igyje0v.py::TestFooCPU::test_bar_cpu\n",
-      "tmp3igyje0v.py::TestFooCPU::test_baz_cpu\n",
-      "tmp3igyje0v.py::TestFooCUDA::test_bar_cuda\n",
-      "tmp3igyje0v.py::TestFooCUDA::test_baz_cuda\n",
+      "tmpyt_bxm9e.py::TestFooCPU::test_bar_cpu\n",
+      "tmpyt_bxm9e.py::TestFooCPU::test_baz_cpu\n",
+      "tmpyt_bxm9e.py::TestFooCUDA::test_bar_cuda\n",
+      "tmpyt_bxm9e.py::TestFooCUDA::test_baz_cuda\n",
       "\n",
       "4 tests collected in 0.01s\n"
      ]
@@ -382,8 +382,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp_xkswyex.py::TestFooCPU::test_bar_cpu_float32\n",
-      "tmp_xkswyex.py::TestFooCPU::test_bar_cpu_int32\n",
+      "tmpttnibud4.py::TestFooCPU::test_bar_cpu_float32\n",
+      "tmpttnibud4.py::TestFooCPU::test_bar_cpu_int32\n",
       "\n",
       "2 tests collected in 0.01s\n"
      ]
@@ -444,8 +444,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpbbuugs6h.py::TestFooCPU::test_bar_add_cpu_int32\n",
-      "tmpbbuugs6h.py::TestFooCPU::test_bar_sub_cpu_float32\n",
+      "tmpe119_vdl.py::TestFooCPU::test_bar_add_cpu_int32\n",
+      "tmpe119_vdl.py::TestFooCPU::test_bar_sub_cpu_float32\n",
       "\n",
       "2 tests collected in 0.04s\n"
      ]
@@ -464,8 +464,6 @@
     "from torch.testing._internal.common_methods_invocations import OpInfo\n",
     "from torch.testing._internal.common_utils import TestCase\n",
     "\n",
-    "\n",
-    "_dispatch_dtypes((torch.float32,))\n",
     "\n",
     "op_db = [\n",
     "    OpInfo(\"add\", dtypesIfCPU=_dispatch_dtypes([torch.int32])), \n",
@@ -513,8 +511,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpfat7ue8d.py::TestFoo::test_bar[add-float32-cpu]\n",
-      "tmpfat7ue8d.py::TestFoo::test_bar[sub-float32-cpu]\n",
+      "tmp8_w7dn68.py::TestFoo::test_bar[add-float32-cpu]\n",
+      "tmp8_w7dn68.py::TestFoo::test_bar[sub-float32-cpu]\n",
       "\n",
       "2 tests collected in 0.00s\n"
      ]
@@ -578,8 +576,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR: not found: /home/user/tmpiuremtop.py::TestFoo::test_bar\n",
-      "(no name '/home/user/tmpiuremtop.py::TestFoo::test_bar' in any of [<Module tmpiuremtop.py>])\n",
+      "ERROR: not found: /home/user/tmpg1b9f42o.py::TestFoo::test_bar\n",
+      "(no name '/home/user/tmpg1b9f42o.py::TestFoo::test_bar' in any of [<Module tmpg1b9f42o.py>])\n",
       "\n"
      ]
     }
@@ -620,8 +618,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpiylcnjen.py::TestFooCPU::test_bar_cpu\n",
-      "tmpiylcnjen.py::TestFooCPU::test_baz_cpu\n",
+      "tmpo9kwbe9q.py::TestFooCPU::test_bar_cpu\n",
+      "tmpo9kwbe9q.py::TestFooCPU::test_baz_cpu\n",
       "\n",
       "2 tests collected in 0.01s\n"
      ]
@@ -653,7 +651,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp7wzpy28y.py::TestFooCPU::test_bar_cpu\n",
+      "tmp_i0_ha5r.py::TestFooCPU::test_bar_cpu\n",
       "\n",
       "1 test collected in 0.04s\n"
      ]
@@ -685,7 +683,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpmjt4e1o8.py::TestFooCPU::test_bar_cpu\n",
+      "tmp633i_bea.py::TestFooCPU::test_bar_cpu\n",
       "\n",
       "1/2 tests collected (1 deselected) in 0.01s\n"
      ]
@@ -717,7 +715,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmplkr5hc9v.py::TestFooCPU::test_spam_cpu\n",
+      "tmpzoevi0fu.py::TestFooCPU::test_spam_cpu\n",
       "\n",
       "1/3 tests collected (2 deselected) in 0.01s\n"
      ]
@@ -781,9 +779,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp_5s_led9.py::TestFooCPU::test_spam_cpu\n",
+      "tmpalkh4ddp.py::TestFooCPU::test_spam_cpu\n",
       "\n",
-      "1 test collected in 0.04s\n"
+      "1 test collected in 0.05s\n"
      ]
     }
    ],
@@ -813,9 +811,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpih9n2q2m.py::TestFooCUDA::test_bar_cuda\n",
+      "tmp6av_zpy3.py::TestFooCUDA::test_bar_cuda\n",
       "\n",
-      "1/2 tests collected (1 deselected) in 0.01s\n"
+      "1/2 tests collected (1 deselected) in 0.02s\n"
      ]
     }
    ],

--- a/posts/2021/06/pytest-pytorch.ipynb
+++ b/posts/2021/06/pytest-pytorch.ipynb
@@ -109,8 +109,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmp2evnfl00.py::TestFoo::test_bar\n",
-      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmp2evnfl00.py::TestFoo::test_bar' in any of [<Module tmp2evnfl00.py>])\n",
+      "ERROR: not found: /home/user/tmp2evnfl00.py::TestFoo::test_bar\n",
+      "(no name '/home/user/tmp2evnfl00.py::TestFoo::test_bar' in any of [<Module tmp2evnfl00.py>])\n",
       "\n"
      ]
     }
@@ -578,8 +578,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmpiuremtop.py::TestFoo::test_bar\n",
-      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmpiuremtop.py::TestFoo::test_bar' in any of [<Module tmpiuremtop.py>])\n",
+      "ERROR: not found: /home/user/tmpiuremtop.py::TestFoo::test_bar\n",
+      "(no name '/home/user/tmpiuremtop.py::TestFoo::test_bar' in any of [<Module tmpiuremtop.py>])\n",
       "\n"
      ]
     }

--- a/posts/2021/06/pytest-pytorch.ipynb
+++ b/posts/2021/06/pytest-pytorch.ipynb
@@ -85,9 +85,7 @@
    "id": "882aa2fb-3119-448e-8742-8dfcb0e7f461",
    "metadata": {},
    "source": [
-    "# Working with [`pytest`] on [PyTorch]\n",
-    "\n",
-    "If you work on PyTorch and like [`pytest`] you may have noticed that you cannot run some tests in the test suite using the default [`pytest`] double colon syntax `{MODULE}::TestFoo::test_bar`.\n",
+    "If you work on [PyTorch] and like [`pytest`] you may have noticed that you cannot run some tests in the test suite using the default [`pytest`] double colon syntax `{MODULE}::TestFoo::test_bar`.\n",
     "\n",
     "[PyTorch]: https://pytorch.org\n",
     "[`pytest`]: https://pytest.org"
@@ -111,8 +109,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmpr457v7ap.py::TestFoo::test_bar\n",
-      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmpr457v7ap.py::TestFoo::test_bar' in any of [<Module tmpr457v7ap.py>])\n",
+      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmp2evnfl00.py::TestFoo::test_bar\n",
+      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmp2evnfl00.py::TestFoo::test_bar' in any of [<Module tmp2evnfl00.py>])\n",
       "\n"
      ]
     }
@@ -210,7 +208,7 @@
       "\n",
       "<ipython-input-2-f22a5e9e7b30>:7: AssertionError\n",
       "================================================================== short test summary info ==================================================================\n",
-      "FAILED tmpxbbbcg2p.py::TestFooCPU::test_bar_cpu - AssertionError: Don't worry, this is supposed to happen!\n",
+      "FAILED tmpaklzvmu7.py::TestFooCPU::test_bar_cpu - AssertionError: Don't worry, this is supposed to happen!\n",
       "1 failed, 1 warning in 0.18s\n"
      ]
     }
@@ -275,10 +273,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpys_atgeq.py::TestFoo::test_bar\n",
-      "tmpys_atgeq.py::TestFoo::test_baz\n",
+      "tmp8ai3jsyh.py::TestFoo::test_bar\n",
+      "tmp8ai3jsyh.py::TestFoo::test_baz\n",
       "\n",
-      "2 tests collected in 0.04s\n"
+      "2 tests collected in 0.03s\n"
      ]
     }
    ],
@@ -318,10 +316,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpkf05zzrh.py::TestFooCPU::test_bar_cpu\n",
-      "tmpkf05zzrh.py::TestFooCPU::test_baz_cpu\n",
-      "tmpkf05zzrh.py::TestFooCUDA::test_bar_cuda\n",
-      "tmpkf05zzrh.py::TestFooCUDA::test_baz_cuda\n",
+      "tmp3igyje0v.py::TestFooCPU::test_bar_cpu\n",
+      "tmp3igyje0v.py::TestFooCPU::test_baz_cpu\n",
+      "tmp3igyje0v.py::TestFooCUDA::test_bar_cuda\n",
+      "tmp3igyje0v.py::TestFooCUDA::test_baz_cuda\n",
       "\n",
       "4 tests collected in 0.01s\n"
      ]
@@ -384,8 +382,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpjznwxkbt.py::TestFooCPU::test_bar_cpu_float32\n",
-      "tmpjznwxkbt.py::TestFooCPU::test_bar_cpu_int32\n",
+      "tmp_xkswyex.py::TestFooCPU::test_bar_cpu_float32\n",
+      "tmp_xkswyex.py::TestFooCPU::test_bar_cpu_int32\n",
       "\n",
       "2 tests collected in 0.01s\n"
      ]
@@ -446,8 +444,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp7x6bf857.py::TestFooCPU::test_bar_add_cpu_int32\n",
-      "tmp7x6bf857.py::TestFooCPU::test_bar_sub_cpu_float32\n",
+      "tmpbbuugs6h.py::TestFooCPU::test_bar_add_cpu_int32\n",
+      "tmpbbuugs6h.py::TestFooCPU::test_bar_sub_cpu_float32\n",
       "\n",
       "2 tests collected in 0.04s\n"
      ]
@@ -515,8 +513,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpzok5g0_v.py::TestFoo::test_bar[add-float32-cpu]\n",
-      "tmpzok5g0_v.py::TestFoo::test_bar[sub-float32-cpu]\n",
+      "tmpfat7ue8d.py::TestFoo::test_bar[add-float32-cpu]\n",
+      "tmpfat7ue8d.py::TestFoo::test_bar[sub-float32-cpu]\n",
       "\n",
       "2 tests collected in 0.00s\n"
      ]
@@ -580,8 +578,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmp4zfeo6bm.py::TestFoo::test_bar\n",
-      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmp4zfeo6bm.py::TestFoo::test_bar' in any of [<Module tmp4zfeo6bm.py>])\n",
+      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmpiuremtop.py::TestFoo::test_bar\n",
+      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmpiuremtop.py::TestFoo::test_bar' in any of [<Module tmpiuremtop.py>])\n",
       "\n"
      ]
     }
@@ -622,8 +620,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpd50vffik.py::TestFooCPU::test_bar_cpu\n",
-      "tmpd50vffik.py::TestFooCPU::test_baz_cpu\n",
+      "tmpiylcnjen.py::TestFooCPU::test_bar_cpu\n",
+      "tmpiylcnjen.py::TestFooCPU::test_baz_cpu\n",
       "\n",
       "2 tests collected in 0.01s\n"
      ]
@@ -655,7 +653,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpymkqhbhi.py::TestFooCPU::test_bar_cpu\n",
+      "tmp7wzpy28y.py::TestFooCPU::test_bar_cpu\n",
       "\n",
       "1 test collected in 0.04s\n"
      ]
@@ -687,7 +685,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmpk82p6pil.py::TestFooCPU::test_bar_cpu\n",
+      "tmpmjt4e1o8.py::TestFooCPU::test_bar_cpu\n",
       "\n",
       "1/2 tests collected (1 deselected) in 0.01s\n"
      ]
@@ -719,7 +717,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmp7h7b3lgf.py::TestFooCPU::test_spam_cpu\n",
+      "tmplkr5hc9v.py::TestFooCPU::test_spam_cpu\n",
       "\n",
       "1/3 tests collected (2 deselected) in 0.01s\n"
      ]
@@ -783,7 +781,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmppb3fskaq.py::TestFooCPU::test_spam_cpu\n",
+      "tmp_5s_led9.py::TestFooCPU::test_spam_cpu\n",
       "\n",
       "1 test collected in 0.04s\n"
      ]
@@ -815,7 +813,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tmplupoqsza.py::TestFooCUDA::test_bar_cuda\n",
+      "tmpih9n2q2m.py::TestFooCUDA::test_bar_cuda\n",
       "\n",
       "1/2 tests collected (1 deselected) in 0.01s\n"
      ]

--- a/posts/2021/06/pytest-pytorch.ipynb
+++ b/posts/2021/06/pytest-pytorch.ipynb
@@ -1,0 +1,908 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "8d86a8f7",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "<summary>Prerequisites</summary>\n",
+    "<p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec468c4e-a3bc-41d5-acc9-10b24c0558fe",
+   "metadata": {},
+   "source": [
+    "To run the code in this post yourself, make sure you have [`torch`](https://pypi.org/project/torch/), [`ipytest>0.9`](https://pypi.org/project/ipytest/), and the plugin to be introduced [`pytest-pytorch`] installed. \n",
+    "\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch\n",
+    "[`ipytest`]: https://github.com/chmp/ipytest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "194122b6-98bc-4b8c-8381-5331471da124",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "    pip install torch 'ipytest>0.9' pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b925ea2c",
+   "metadata": {},
+   "source": [
+    "Before we start testing, we need to configure [`ipytest`]. We use the [`ipytest.autoconfig()`](https://github.com/chmp/ipytest#ipytestautoconfig) as base and add some [`pytest` CLI flags](https://docs.pytest.org/en/stable/reference.html#command-line-flags) in order to get a concise output.\n",
+    "\n",
+    "[`ipytest`]: https://github.com/chmp/ipytest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1f78b73a-1d7b-47bc-83b9-62d2ac9149cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipytest\n",
+    "\n",
+    "ipytest.autoconfig(defopts=False)\n",
+    "\n",
+    "default_flags = (\"--quiet\", \"--disable-warnings\")\n",
+    "\n",
+    "def _configure_ipytest(*additional_flags, collect_only=False):\n",
+    "    addopts = list(default_flags)\n",
+    "    if collect_only:\n",
+    "        addopts.append(\"--collect-only\")\n",
+    "    addopts.extend(additional_flags)\n",
+    "    \n",
+    "    ipytest.config(addopts=addopts)\n",
+    "\n",
+    "def enable_pytest_pytorch(collect_only=False):\n",
+    "    _configure_ipytest(collect_only=collect_only)\n",
+    "    \n",
+    "def disable_pytest_pytorch(collect_only=False):\n",
+    "    _configure_ipytest(\"--disable-pytest-pytorch\", collect_only=collect_only)\n",
+    "    \n",
+    "disable_pytest_pytorch()"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "6bd53f21",
+   "metadata": {},
+   "source": [
+    "</p>\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "882aa2fb-3119-448e-8742-8dfcb0e7f461",
+   "metadata": {},
+   "source": [
+    "# Working with [`pytest`] on [PyTorch]\n",
+    "\n",
+    "If you work on PyTorch and like [`pytest`] you may have noticed that you cannot run some tests in the test suite using the default [`pytest`] double colon syntax `{MODULE}::TestFoo::test_bar`.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fac67c59-1856-413e-b4ad-e76b5b238cbe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "1 warning in 0.01s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmpr457v7ap.py::TestFoo::test_bar\n",
+      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmpr457v7ap.py::TestFoo::test_bar' in any of [<Module tmpr457v7ap.py>])\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}::TestFoo::test_bar\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "from torch.testing._internal.common_device_type import instantiate_device_type_tests\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    def test_bar(self, device):\n",
+    "        assert False, \"Don't worry, this is supposed to happen!\"\n",
+    "\n",
+    "    \n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=[\"cpu\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18124042-2b64-490e-a2c2-45750eda830c",
+   "metadata": {},
+   "source": [
+    "If the absence of this very basic [`pytest`] feature has ever been the source of frustration for you, you don't need to worry anymore. By installing the [`pytest-pytorch`] plugin with\n",
+    "\n",
+    "[`pytest`]: https://pytest.org\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "987a3e60-cce6-428f-ac83-41bff34eb433",
+   "metadata": {},
+   "source": [
+    "    pip install pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00544cec-3675-4cf0-a595-b95921a06600",
+   "metadata": {},
+   "source": [
+    "or"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28d707b6-19fa-4ea7-8a48-4c600e6b9d8c",
+   "metadata": {},
+   "source": [
+    "    conda install -c conda-forge pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1839e3b-6abf-4b5a-b28d-e5086e53dc76",
+   "metadata": {},
+   "source": [
+    "you get the default [`pytest`] experience back even if your workflow involves running tests from within your IDE!\n",
+    "\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f266cfce-5341-4f19-92fe-31221ca7e282",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enable_pytest_pytorch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6b06b5b1-f5a7-4115-893f-60e4fc555664",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "F                                                                                                                                                     [100%]\n",
+      "========================================================================= FAILURES ==========================================================================\n",
+      "__________________________________________________________________ TestFooCPU.test_bar_cpu __________________________________________________________________\n",
+      "\n",
+      "self = <__main__.TestFooCPU testMethod=test_bar_cpu>, device = 'cpu'\n",
+      "\n",
+      "    def test_bar(self, device):\n",
+      ">       assert False, \"Don't worry, this is supposed to happen!\"\n",
+      "E       AssertionError: Don't worry, this is supposed to happen!\n",
+      "E       assert False\n",
+      "\n",
+      "<ipython-input-2-f22a5e9e7b30>:7: AssertionError\n",
+      "================================================================== short test summary info ==================================================================\n",
+      "FAILED tmpxbbbcg2p.py::TestFooCPU::test_bar_cpu - AssertionError: Don't worry, this is supposed to happen!\n",
+      "1 failed, 1 warning in 0.18s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest {MODULE}::TestFoo::test_bar\n",
+    "                \n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd3b1b9f-9bc5-4c69-9123-4deb63e8c2b3",
+   "metadata": {},
+   "source": [
+    "As you can see, with [`pytest-pytorch`] enabled, [`pytest`] ran the correct test but collected it under a different name. In this post we are going to find out why this is happening and what [`pytest-pytorch`] does to make your life easier.\n",
+    "\n",
+    "[`pytest`]: https://pytest.org\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4a96448",
+   "metadata": {},
+   "source": [
+    "<!-- TEASER_END -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65cc3dc5-2da4-471f-be93-c65f4d740996",
+   "metadata": {},
+   "source": [
+    "## [PyTorch] test generation\n",
+    "\n",
+    "[PyTorch] has an extensive test suite with a lot of [configuration options and auto-generated tests](https://github.com/pytorch/pytorch/wiki/Running-and-writing-tests-in-PyTorch-1.9). Internally, [PyTorch] uses a `TestCase` class that is derived from [`unittest.TestCase`](https://docs.python.org/3/library/unittest.html#unittest.TestCase). In the first part of the post we are going to explore how the auto-generation of tests works in the [PyTorch] test suite and how they are collected by [`pytest`].\n",
+    "\n",
+    "In its default definition [PyTorch]'s `TestCase` behaves exactly like its base class with regards to test collection.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c56aff78-38cb-4f89-952d-1ada6f45d676",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "disable_pytest_pytorch(collect_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0e4ddee5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpys_atgeq.py::TestFoo::test_bar\n",
+      "tmpys_atgeq.py::TestFoo::test_baz\n",
+      "\n",
+      "2 tests collected in 0.04s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    def test_bar(self):\n",
+    "        pass\n",
+    "\n",
+    "    def test_baz(self):\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9be76b6b-f4fa-49d8-bfdc-d2e65addfdb7",
+   "metadata": {},
+   "source": [
+    "### Device parametrization\n",
+    "\n",
+    "Most `TestCase`'s use additional configuration, though. In [PyTorch], most operations can be performed on other `device`'s than the CPU, for example a GPU. Thus, to [not repeat yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) by writing the same test for multiple `device`'s, the possible devices are used as parameters for the test. In [PyTorch] this is done with the `instantiate_device_type_tests` function. \n",
+    "\n",
+    "[PyTorch]: https://pytorch.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1905c07d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpkf05zzrh.py::TestFooCPU::test_bar_cpu\n",
+      "tmpkf05zzrh.py::TestFooCPU::test_baz_cpu\n",
+      "tmpkf05zzrh.py::TestFooCUDA::test_bar_cuda\n",
+      "tmpkf05zzrh.py::TestFooCUDA::test_baz_cuda\n",
+      "\n",
+      "4 tests collected in 0.01s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "from torch.testing._internal.common_device_type import instantiate_device_type_tests\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    def test_bar(self, device):\n",
+    "        pass\n",
+    "\n",
+    "    def test_baz(self, device):\n",
+    "        pass\n",
+    "\n",
+    "    \n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=[\"cpu\", \"cuda\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "856e0f10-1952-4d02-88ff-b652fd62cc51",
+   "metadata": {},
+   "source": [
+    "As the name implies, `instantiate_device_type_tests` uses the passed test case as template to instantiate new test cases from it for the different `device`'s. In this process the names of test cases as well as its test functions are changed:\n",
+    "- The test case is namespaced by postfixing the `device` name in uppercase letters (`TestFoo` ⟶ `TestFooCPU`)\n",
+    "- Each test function is namespaced by postfixing the `device` name in lower case letters and an additional underscore as separator (`test_bar` ⟶ `test_bar_cpu`)\n",
+    "\n",
+    "After the instatiation, the current tested `device` is supplied to each test function. \n",
+    "\n",
+    "We are glossing over many details here, two of which I should at least mention:\n",
+    "\n",
+    "1. Although it looks like only the test functions need to be parametrized, the parametrized test cases perform different setup and teardown on a per-`device` basis.\n",
+    "2. There are many decorators available that allow to adapt the `device` parametrization on a per-function basis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1727ae2e-9ce8-4cee-970a-5b25bcd8c653",
+   "metadata": {},
+   "source": [
+    "### Data type parametrization\n",
+    "\n",
+    "In the same spirit as the `device` parametrizations, most [PyTorch] operators support a [plethora of data types](https://pytorch.org/docs/stable/tensor_attributes.html#torch-dtype) (`dtype`'s in short). We can parametrize a test function with the `@dtypes` decorator, after which the `dtype` is available as parameter. Note that we can only use the `@dtypes` decorator if templating is enabled, which means that we have to use `instantiate_device_type_tests`.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1aa198d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpjznwxkbt.py::TestFooCPU::test_bar_cpu_float32\n",
+      "tmpjznwxkbt.py::TestFooCPU::test_bar_cpu_int32\n",
+      "\n",
+      "2 tests collected in 0.01s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "from torch.testing._internal.common_device_type import (\n",
+    "    instantiate_device_type_tests,\n",
+    "    dtypes,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    @dtypes(torch.int32, torch.float32)\n",
+    "    def test_bar(self, device, dtype):\n",
+    "        pass\n",
+    "\n",
+    "\n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=\"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a54cf5a5-eb2c-4182-af54-6e76fcf72fa8",
+   "metadata": {},
+   "source": [
+    "Similar to the device parametrization, the `dtype` name is postfixed to the name of the test function after the `device` (`test_bar` ⟶ `test_bar_cpu_float32`). Since there is no need for special setup or teardown on a per-`dtype` basis, the test case is not instatiatied for different `dtype`'s (`TestFoo` ⟶ `TestFooCPU`).\n",
+    "\n",
+    "Again, there are more decorators available for granular control, but they go beyond the scope of this post."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8de16aa6-a71b-4215-9c91-6cb4bc0374d1",
+   "metadata": {},
+   "source": [
+    "### Operator parametrization\n",
+    "\n",
+    "A recent addition to the [PyTorch] test suite is the `OpInfo` class. It carries the meta data of an operator such as per-`device` supported `dtype`'s or an optional reference function from another library. Going through all options would facilitate a blog post on its own, so we are going to stick to the basics here.\n",
+    "\n",
+    "`OpInfo`'s enable even less duplicated code. For example, the test structure for checking an operator against a reference implementation is operator-agnostic. To parametrize a test function, we use the `@ops` decorator. We define our own `op_db` here, but in the [PyTorch] test suite there are pre-defined databases, for different operator types such as unary or binary operators. Again, note that we can only use the `@ops` decorator if templating is enabled, which means that we have to use `instantiate_device_type_tests`.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "339b3ed3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmp7x6bf857.py::TestFooCPU::test_bar_add_cpu_int32\n",
+      "tmp7x6bf857.py::TestFooCPU::test_bar_sub_cpu_float32\n",
+      "\n",
+      "2 tests collected in 0.04s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "from torch.testing import _dispatch_dtypes\n",
+    "from torch.testing._internal.common_device_type import (\n",
+    "    instantiate_device_type_tests,\n",
+    "    ops,\n",
+    ")\n",
+    "from torch.testing._internal.common_methods_invocations import OpInfo\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "\n",
+    "\n",
+    "_dispatch_dtypes((torch.float32,))\n",
+    "\n",
+    "op_db = [\n",
+    "    OpInfo(\"add\", dtypesIfCPU=_dispatch_dtypes([torch.int32])), \n",
+    "    OpInfo(\"sub\", dtypesIfCPU=_dispatch_dtypes([torch.float32])),\n",
+    "]\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    @ops(op_db)\n",
+    "    def test_bar(self, device, dtype, op):\n",
+    "        pass\n",
+    "\n",
+    "\n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=\"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "632fc3a5-c297-49be-8ffb-b556061c80bb",
+   "metadata": {},
+   "source": [
+    "In contrast to the `dtype`, the `op` name is placed before the `device` identifier in the name of a test function (`test_bar` ⟶ `test_bar_add_cpu_int32`). Still, no special setup or teardown is needed on a per-`op` basis, so the test case is only instantiated for the `device` (`TestFoo` ⟶ `TestFooCPU`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99f4d882-cc30-42a7-ab45-f417fa9dbf40",
+   "metadata": {},
+   "source": [
+    "### [`pytest`] \"equivalent\"\n",
+    "\n",
+    "From a [`pytest`] perspective, the [PyTorch] test generation is \"equivalent\" to using the `@pytest.mark.parametrize` decorator. Of course this ignores all the gory details, which makes it seem easier than it is. Still, it might be a good mental analogy for someone coming from a [`pytest`] background.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f1496422",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpzok5g0_v.py::TestFoo::test_bar[add-float32-cpu]\n",
+      "tmpzok5g0_v.py::TestFoo::test_bar[sub-float32-cpu]\n",
+      "\n",
+      "2 tests collected in 0.00s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}\n",
+    "\n",
+    "import pytest\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "\n",
+    "@pytest.mark.parametrize(\"device\", [\"cpu\"])\n",
+    "class TestFoo:\n",
+    "    @pytest.mark.parametrize(\"dtype\", [pytest.param(torch.float32, id=\"float32\")])\n",
+    "    @pytest.mark.parametrize(\"op\", [\"add\", \"sub\"])\n",
+    "    def test_bar(self, device, dtype, op):\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bea9900a-2ade-405a-aa29-fb2c5df903c0",
+   "metadata": {},
+   "source": [
+    "So far we looked at the test generation in the [PyTorch] test suite and how the tests are collected by [`pytest`]. Although [PyTorch] uses a different parametrization scheme than [`pytest`], it is 100% compatible. The problems only materialize if you want select a specific test case or test function rather than say a whole module or the complete test suite.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb139e07-2b66-4458-b78e-252d30130569",
+   "metadata": {},
+   "source": [
+    "## [PyTorch] test selection with [`pytest`]\n",
+    "\n",
+    "As we observed above, [`pytest`]'s default double colon `::` notation, does not work on tests instantiated by [PyTorch]'s test suite.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "069e060d-9457-4bd6-9e2c-58ac6c6d0a2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "no tests collected in 0.01s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR: not found: /home/philip/git/quansight-labs-site/posts/2021/06/tmp4zfeo6bm.py::TestFoo::test_bar\n",
+      "(no name '/home/philip/git/quansight-labs-site/posts/2021/06/tmp4zfeo6bm.py::TestFoo::test_bar' in any of [<Module tmp4zfeo6bm.py>])\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}::TestFoo::test_bar\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "from torch.testing._internal.common_device_type import instantiate_device_type_tests\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    def test_bar(self, device):\n",
+    "        pass\n",
+    "    \n",
+    "    def test_baz(self, device):\n",
+    "        pass\n",
+    "\n",
+    "    \n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=[\"cpu\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17b19f45-288e-4acc-a5e5-ae50f534a35c",
+   "metadata": {},
+   "source": [
+    "Equipped with the knowledge we gathered about the instantiation, it is easy to see why this is happening."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e3d7e4f0-f29e-4b44-89c3-1b0e2f9d5108",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpd50vffik.py::TestFooCPU::test_bar_cpu\n",
+      "tmpd50vffik.py::TestFooCPU::test_baz_cpu\n",
+      "\n",
+      "2 tests collected in 0.01s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest {MODULE}\n",
+    "\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "946f21a7-0ec7-43be-81dc-746565c5a57b",
+   "metadata": {},
+   "source": [
+    "[`pytest`] searches for the test case `TestFoo` with the test function `test_bar`, but can't find them, because `instantiate_device_type_tests` renamed them to `TestFooCPU` and `test_bar_cpu`. However, the test is selectable by its new, instantiated name `{MODULE}::TestFooCPU::test_bar_cpu`\n",
+    "\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "28612ce9-db7f-4d80-ad97-b2d23766e401",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpymkqhbhi.py::TestFooCPU::test_bar_cpu\n",
+      "\n",
+      "1 test collected in 0.04s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest {MODULE}::TestFooCPU::test_bar_cpu\n",
+    "                \n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5201ca9c-4cf9-454f-8ceb-dbafd0f3a6fc",
+   "metadata": {},
+   "source": [
+    "From a convenience standpoint this is not optimal, because we need to remember the naming scheme. Furthermore, we can only select a specific parametrization rather than running a test case or a test function against all available parametrizations. The usual way around this is to rely on the [`pytest` `-k` flag] to do a pattern matching.\n",
+    "\n",
+    "[`pytest` `-k` flag]: https://docs.pytest.org/en/stable/reference.html#command-line-flags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "fd4edb43-78c6-4736-a567-0b039e5e0a1a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmpk82p6pil.py::TestFooCPU::test_bar_cpu\n",
+      "\n",
+      "1/2 tests collected (1 deselected) in 0.01s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest {MODULE} -k \"TestFoo and test_bar\"\n",
+    "                \n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "224abff3-47ea-4079-9798-1fd259eb9f6a",
+   "metadata": {},
+   "source": [
+    "In contrast to the default [`pytest`] practice we need to include the names of the test case and test function in the pattern rather than only the parametrization we want to select. This brings its own set of problems with it, for example if test cases or test functions use names that build on top of each other. Since the selection pattern does not support regular expression matching, it can get verbose and confusing.\n",
+    "\n",
+    "[`pytest`]: https://pytest.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "8836d29a-3c42-4bd0-9710-30889c93ad6b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmp7h7b3lgf.py::TestFooCPU::test_spam_cpu\n",
+      "\n",
+      "1/3 tests collected (2 deselected) in 0.01s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE} -k \"TestFoo and not TestFooBar and test_spam and not test_spam_ham\"\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "from torch.testing._internal.common_device_type import instantiate_device_type_tests\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    def test_spam(self, device):\n",
+    "        pass\n",
+    "    \n",
+    "    def test_spam_ham(self, device):\n",
+    "        pass\n",
+    "\n",
+    "    \n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=\"cpu\")\n",
+    "    \n",
+    "    \n",
+    "class TestFooBar(TestCase):\n",
+    "    def test_spam(self, device):\n",
+    "        pass\n",
+    "\n",
+    "\n",
+    "instantiate_device_type_tests(TestFooBar, globals(), only_for=\"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff9804c8-dfc9-4b01-bcdb-69324354b79e",
+   "metadata": {},
+   "source": [
+    "### [`pytest-pytorch`]\n",
+    "\n",
+    "Introducing: [`pytest-pytorch`]. After its installation and without any configuration, we get the default [`pytest`] experience back. Thus, even in complicated naming situations we can simply select a test with the double colon notation `{MODULE}::TestFoo::test_spam`\n",
+    "\n",
+    "[`pytest`]: https://pytest.org\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "14a41e7d-914a-411e-b601-16c5b01961af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enable_pytest_pytorch(collect_only=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "86dae795-dad9-4fed-89cf-8d69230f83ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmppb3fskaq.py::TestFooCPU::test_spam_cpu\n",
+      "\n",
+      "1 test collected in 0.04s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest {MODULE}::TestFoo::test_spam\n",
+    "                \n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4116458b-e060-480e-aece-48c699f3d511",
+   "metadata": {},
+   "source": [
+    "Of course we can still use the [`pytest` `-k` flag] to select a specific parametrization.\n",
+    "\n",
+    "[`pytest` `-k` flag]: https://docs.pytest.org/en/stable/reference.html#command-line-flags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d2f20f84-b000-4e34-9b90-47fecbb3de70",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tmplupoqsza.py::TestFooCUDA::test_bar_cuda\n",
+      "\n",
+      "1/2 tests collected (1 deselected) in 0.01s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%run_pytest[clean] {MODULE}::TestFoo::test_bar -k \"cuda\"\n",
+    "\n",
+    "from torch.testing._internal.common_utils import TestCase\n",
+    "from torch.testing._internal.common_device_type import instantiate_device_type_tests\n",
+    "\n",
+    "\n",
+    "class TestFoo(TestCase):\n",
+    "    def test_bar(self, device):\n",
+    "        pass\n",
+    "\n",
+    "    \n",
+    "instantiate_device_type_tests(TestFoo, globals(), only_for=[\"cpu\", \"cuda\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e6eb06-6806-4770-b600-99ca0c5ca32e",
+   "metadata": {},
+   "source": [
+    "Handwaving over details [`pytest-pytorch`] achieves this by hooking into [`pytest`]'s test collection and performing the matching of the instantiated to the template name for you. If that sounds intruiging, have a look at the [GitHub repository](https://github.com/Quansight/pytest-pytorch).\n",
+    "\n",
+    "[`pytest`]: https://pytest.org\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b736bf-2592-4faf-b117-79c0d1db0bd0",
+   "metadata": {},
+   "source": [
+    "### IDEs with [`pytest`] support\n",
+    "\n",
+    "Another use case for [`pytest-pytorch`] are modern Python IDEs such as [PyCharm](https://www.jetbrains.com/help/pycharm/pytest.html#run-pytest-test) or [VSCode](https://code.visualstudio.com/docs/python/testing#_run-tests) with built-in [`pytest`] support. Within such an IDE you can run a test by clicking a button next to its definition without dropping into a terminal. Doing this, you also get the comfort of the IDE including the debugger.\n",
+    "\n",
+    "This feature relies on the test selection with the default [`pytest`] syntax, which, as we have seen above, does not work well with the [PyTorch] test suite. You could fiddle with your IDEs default test runner config or you could simply install [`pytest-pytorch`] to make it work out of the box.\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dc062e1-fe59-4656-aebd-613001687869",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "In this post we took a look at how the [PyTorch] test suite auto-generates `device`-, `dtype`-, and even operator-agnostic tests. Although it uses a different scheme than [`pytest`], the tests can still be collected and run by it. The compatibility breaks down, if one tries to use the default [`pytest`] selection notation. To overcome this and in turn enhance the developer experience we introduced the [`pytest-pytorch`] plugin. It can for example be used to regain out-of-the-box [`pytest`] support in modern IDEs when working on [PyTorch].\n",
+    "\n",
+    "[PyTorch]: https://pytorch.org\n",
+    "[`pytest`]: https://pytest.org\n",
+    "[`pytest-pytorch`]: https://github.com/Quansight/pytest-pytorch"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  },
+  "nikola": {
+   "author": "Philip Meier",
+   "date": "2021-06-21 11:35:06 UTC",
+   "slug": "pytest-pytorch",
+   "title": "Working with pytest on PyTorch"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is the official introduction of [`pytest-pytorch`](https://github.com/Quansight/pytest-pytorch) that will be linked from the PyTorch developer wiki.