### PR TITLE
ENH Supports multiple authors

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -462,6 +462,9 @@ HIDDEN_CATEGORIES = []
 # Tag pages will still be generated.
 HIDDEN_AUTHORS = ['Guest']
 
+# Allow multiple, comma-separated authors for a post? (Requires theme support, present in built-in themes)
+MULTIPLE_AUTHORS_PER_POST = True
+
 # Final location for the main blog page and sibling paginated pages is
 # output / TRANSLATION[lang] / INDEX_PATH / index-*.html
 # (translatable)

--- a/posts/2020/11/design_in_open_source.md
+++ b/posts/2020/11/design_in_open_source.md
@@ -2,7 +2,7 @@
 .. title: Introduction to Design in Open Source
 .. slug: introduction-to-design-in-open-source
 .. date: 2020-11-18 00:00:30 UTC-05:00
-.. author: Tim George and Isabela Presedo-Floyd
+.. author: Tim George, Isabela Presedo-Floyd
 .. tags: design, UX, User Experience, Open-Source,
 .. category:
 .. link:

--- a/posts/2020/12/jupyterlab-winter-theme.md
+++ b/posts/2020/12/jupyterlab-winter-theme.md
@@ -2,7 +2,7 @@
 .. title: Develop a JupyterLab Winter Theme
 .. slug: jupyterlab-winter-theme
 .. date: 2020-12-22 09:00:00 UTC-00:00
-.. author: Matthias Bussonnier, Isabela Presedo Floyd, Eric Charles, Eric Kelly, Tony Fast
+.. author: Matthias Bussonnier, Isabela Presedo-Floyd, Eric Charles, Eric Kelly, Tony Fast
 .. tags: Labs, Jupyter, Theme, JupyterLab, JupyterTutorials
 .. category:
 .. link:

--- a/posts/2021/04/spot-the-differences.md
+++ b/posts/2021/04/spot-the-differences.md
@@ -2,7 +2,7 @@
 .. title: Spot the differences: what is new in Spyder 5?
 .. slug: spot-the-diffenrences
 .. date: 2021-04-16 08:00:00 UTC-06:00
-.. author: Isabela Presedo-Floyd and Juanita Gomez
+.. author: Isabela Presedo-Floyd, Juanita Gomez
 .. tags: Spyder, UX/UI, release
 .. category:
 .. link:

--- a/posts/2021/07/better-interractive-jupyter-session-with-pyflyby.md
+++ b/posts/2021/07/better-interractive-jupyter-session-with-pyflyby.md
@@ -2,7 +2,7 @@
 .. title: Pyflyby: Improving Efficiency of Jupyter Interactive Sessions
 .. slug: pyflyby-improving-efficiency-of-jupyter-interactive-sessions
 .. date: 2021-07-07 10:00:00 UTC-00:00
-.. author: Matthias Bussonnier, Aaron Meurer,
+.. author: Matthias Bussonnier, Aaron Meurer
 .. tags: Labs, Pyflyby, Deshaw
 .. category:
 .. link:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ commonmark==0.9.1
 decorator==4.4.0
 defusedxml==0.6.0
 docutils==0.15.2
-doit==0.31.1
+doit==0.33.1
 entrypoints==0.3
 ghp-import2==1.0.1
 husl==4.0.3
@@ -38,7 +38,7 @@ multidict==4.5.2
 natsort==6.0.0
 nbconvert==5.6.0
 nbformat==5.1.2
-Nikola==8.0.4
+Nikola==8.1.3
 notebook==6.1.5
 pandocfilters==1.4.2
 parso==0.5.1

--- a/themes/quansightlabs/templates/index.tmpl
+++ b/themes/quansightlabs/templates/index.tmpl
@@ -38,7 +38,11 @@
         <h1 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h1>
         <div class="metadata">
             <p class="byline author vcard"><span class="byline-name fn" itemprop="author">
-            % if author_pages_generated:
+            % if author_pages_generated and multiple_authors_per_post:
+                % for author in post.authors():
+                    <a href="${_link('author', author)}">${author|h}</a>
+                % endfor
+            % elif author_pages_generated:
                 <a href="${_link('author', post.author())}">${post.author()|h}</a>
             % else:
                 ${post.author()|h}

--- a/themes/quansightlabs/templates/post_header.tmpl
+++ b/themes/quansightlabs/templates/post_header.tmpl
@@ -43,7 +43,11 @@
         ${html_title()}
         <div class="metadata">
             <p class="byline author vcard p-author h-card"><span class="byline-name fn p-name" itemprop="author">
-                % if author_pages_generated:
+                % if author_pages_generated and multiple_authors_per_post:
+                     % for author in post.authors():
+                         <a class="u-url" href="${_link('author', author)}">${author|h}</a>
+                     % endfor
+                % elif author_pages_generated:
                     <a class="u-url" href="${_link('author', post.author())}">${post.author()|h}</a>
                 % else:
                     ${post.author()|h}


### PR DESCRIPTION
Multiple author support was added in nikola 8.1.2. This PR adds multiple author support to the labs website.

Before an "author" is the complete string defined by the metadata "author" tag:

![Screen Shot 2021-07-07 at 1 50 31 PM](https://user-images.githubusercontent.com/5402633/124806102-51448e80-df2a-11eb-9c18-f33509d377ce.png)

With this PR every author gets their own author page:

![Screen Shot 2021-07-07 at 1 51 17 PM](https://user-images.githubusercontent.com/5402633/124806197-6b7e6c80-df2a-11eb-8acc-0a01af36fffd.png)

![Screen Shot 2021-07-07 at 1 53 12 PM](https://user-images.githubusercontent.com/5402633/124806445-b26c6200-df2a-11eb-91a5-08c5984f0251.png)
