### PR TITLE
Enable utterances (comment system) on the blog.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -896,12 +896,12 @@ RSS_COPYRIGHT_FORMATS = CONTENT_FOOTER_FORMATS
 # systems.  The following comment systems are supported by Nikola:
 #   disqus, facebook, intensedebate, isso, muut, commento
 # You can leave this option blank to disable comments.
-COMMENT_SYSTEM = ""
+COMMENT_SYSTEM = "utterances"
 # And you also need to add your COMMENT_SYSTEM_ID which
 # depends on what comment system you use. The default is
 # "nikolademo" which is a test account for Disqus. More information
 # is in the manual.
-COMMENT_SYSTEM_ID = ""
+COMMENT_SYSTEM_ID = "Quansight-Labs/quansight-labs-site"
 
 # Create index.html for page folders?
 # WARNING: if a page would conflict with the index file (usually
@@ -1278,7 +1278,15 @@ WARN_ABOUT_TAG_METADATA = False
 
 # Put in global_context things you want available on all your templates.
 # It can be anything, data, functions, modules, etc.
-GLOBAL_CONTEXT = {}
+
+GLOBAL_CONTEXT = {
+    "utterances_config": {
+        "issue-term": "title",
+        "label": "utterances",
+        "theme": "github-light",
+        "crossorigin": "anonymous",
+    }
+}
 
 # Add functions here and they will be called with template
 # GLOBAL_CONTEXT as parameter when the template is about to be


### PR DESCRIPTION
Before merging:
 - [x] A label named "utterances" need to be created in the repo
 - [x] The utterance bot needs to be installed on this repo via https://github.com/apps/utterances/installations/new

-- 

[Here](https://elegant-bhaskara-0c18b3.netlify.app/blog/2021/07/pyflyby-improving-efficiency-of-jupyter-interactive-sessions/) is how it looks like (on a fork of mine, with a different config to comment on a different repo), and [here is the issue](https://github.com/Carreau/quansight-labs-site/issues/2) the utterance bot create on the fork.

(You can try to comment on above demo deployment, but be carefull the redirect is incorrect, and you will need to mess with the URL once you've authorized github)