### PR TITLE
Unify author spelling.

### DIFF
--- a/posts/2019/09/ruby-wrappers-for-the-xnd-project.md
+++ b/posts/2019/09/ruby-wrappers-for-the-xnd-project.md
@@ -2,7 +2,7 @@
 .. title: Ruby wrappers for the XND project
 .. slug: ruby-wrappers-for-the-xnd-project
 .. date: 2019-09-15 00:32:00 UTC-05:00
-.. author: Sameer Deshmukh (@v0dro)
+.. author: Sameer Deshmukh
 .. tags: 
 .. category: 
 .. link: 

--- a/posts/2019/11/Files-Improvements.md
+++ b/posts/2019/11/Files-Improvements.md
@@ -2,7 +2,7 @@
 .. title: File management improvements in Spyder4
 .. slug: File-management-improvements-in-Spyder4
 .. date: 2019-11-12 12:00:00 UTC-05:00
-.. author: Juanita Gomez & Gonzalo Peña
+.. author: Juanita Gomez, Gonzalo Peña
 .. tags: Labs, Spyder
 .. category: 
 .. link: 

--- a/posts/2020/03/documentation-as-a-way-to-build-community.md
+++ b/posts/2020/03/documentation-as-a-way-to-build-community.md
@@ -2,7 +2,7 @@
 .. title: Documentation as a way to build Community
 .. slug: documentation-as-a-way-to-build-community
 .. date: 2020-03-14 07:25:55 UTC-05:00
-.. author: Melissa Mendonça
+.. author: Melissa Weber Mendonça
 .. tags: Labs, NumPy
 .. category: 
 .. link: 

--- a/posts/2021/08/czi-eoss4-grants-at-quansight-labs.md
+++ b/posts/2021/08/czi-eoss4-grants-at-quansight-labs.md
@@ -7,7 +7,7 @@
 .. link:
 .. description:
 .. type: markdown
-.. author: Thomas Fan, Aaron Meurer,Melissa Mendonça,Tania Allard, Matthias Bussonnier, Isabela Presedo-Floyd, Ralf Gommers, Travis Oliphant
+.. author: Thomas Fan, Aaron Meurer,Melissa Weber Mendonça,Tania Allard, Matthias Bussonnier, Isabela Presedo-Floyd, Ralf Gommers, Travis Oliphant
 -->
 
 Here, at Quansight Labs, our goal is to work on sustaining the future of Open Source. We make sure we can live up to that goal by spending a significant amount of time working on impactful and critical infrastructure and projects within the Scientific Ecosystem.


### PR DESCRIPTION
Making sure we are using & as separator, using full spelling of author
names with no other characters to make sure this page list authors only
once:

https://labs.quansight.org/authors/

@melissawm Just want to make sure it's the right fix, or do you prefer me to unify as "Melissa Mendonça" ?