### PR TITLE
Update dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ ghp-import2==1.0.1
 husl==4.0.3
 idna==2.8
 importlib-metadata==1.6.0
-ipykernel==5.1.2
-ipython==7.7.0
+ipykernel==5.5.5
+ipython==7.19.0
 ipython-genutils==0.2.0
 jedi==0.15.1
 Jinja2==2.11.3
@@ -71,7 +71,7 @@ terminado==0.8.3
 testpath==0.4.2
 toml==0.10.0
 tornado==6.0.3
-traitlets==4.3.2
+traitlets==5.1.0
 typogrify==2.0.7
 Unidecode==1.1.1
 urllib3==1.26.5


### PR DESCRIPTION
This bumps some dependencies to latest version.
Ideally we should get both a requirements.txt and requirment.txt.lock
where one has only the actual required libraries and the other all the
pinned versions, so that we can easily update and freeze again, but
that's likely for another time.

I've rebuild locally with both old dependencies and new one to make sure
that the generated content is identical to some variation of the date
and of the XML attribute ordering.