### PR TITLE
Add teaser end tag Jupyter Accessibility Post 3

### DIFF
--- a/posts/2021/09/not-a-checklist.md
+++ b/posts/2021/09/not-a-checklist.md
@@ -24,6 +24,8 @@ for users. Here it is, the moment of truth!
 
 And they each say totally different things. 
 
+<!-- TEASER_END -->
+
 What? Is that not a very funny joke? You’re right, it’s not funny at all; this 
 is a real problem we faced.
 


### PR DESCRIPTION
Related to #229

I forgot to put a `<!-- TEASER_END -->` tag to denote the end of my post's summary! Sorry about that, and thanks for pointing it out @rgommers.

Please let me know if it seems like I've missed anything else.