### PR TITLE
Remove redundant markdown header in the recent low-code post

### DIFF
--- a/posts/2021/09/low-code-workshop.md
+++ b/posts/2021/09/low-code-workshop.md
@@ -11,8 +11,6 @@
 -->
 
 
-# Low-code contributions through GitHub
-
 Healthy, inclusive communities are critical to impactful open source projects.
 A challenge for established projects is that the history and implicit technical
 debt increase the barrier to contribute to significant portions of code base.


### PR DESCRIPTION
Prevents duplication of the header in the [recent post](https://labs.quansight.org/blog/2021/09/low-code-contributions-through-GitHub/)