### PR TITLE
Errata: blog/2021/10/cxx-numba-interoperability

### DIFF
--- a/posts/2021/10/cxx-numba-interoperability.md
+++ b/posts/2021/10/cxx-numba-interoperability.md
@@ -43,7 +43,7 @@ originates from the
 compilers apply to function names in order to support function/method
 overloadings as well as other relevant C++ language features. In
 principle, one would be able to call such a C++ library function
-directly from any Numba compiled function (using the 
+directly from any Numba compiled function (using the
 [numba.cfunc](https://numba.pydata.org/numba-doc/latest/user/cfunc.html)
 feature) if one would knows how the C++ compiler transforms the
 function name internally . However, the name-mangling algorithm is C++
@@ -59,11 +59,11 @@ determining the addresses of C++ library functions at runtime which
 together with functions signatures are then used to set up a highly
 efficient calling sequence.  This method will require creating a small
 C/C++ wrapper library that contains ``extern "C"``-attributed
-functions which return the addresses of C++ library functions and 
+functions which return the addresses of C++ library functions and
 can be easily called from Python using various techniques, here we use
 [ctypes](https://docs.python.org/3/library/ctypes.html).
 
-We provida here a Python script [cxx2py.py](https://raw.githubusercontent.com/Quansight-Labs/quansight-labs-site/main/posts/2021/10/cxx2py.py) that
+We provide here a Python script [cxx2py.py](https://raw.githubusercontent.com/Quansight-Labs/quansight-labs-site/main/posts/2021/10/cxx2py.py) that
 auto-generates, from a user-supplied C++ header and source files, the
 C/C++ wrapper library as well as a Python
 [ctypes](https://docs.python.org/3/library/ctypes.html) wrapper
@@ -250,7 +250,7 @@ functions. For example:
 >>> @numba.njit
 ... def fun(x):
 ...     return libfoo.foo(x + 2)
-... 
+...
 >>> fun(5)
 in foo(7)
 130


### PR DESCRIPTION
<!--Hi there! If you aren't submitting a blog post, you can delete this message.

Thank you for submitting a blog post! We want to make sure content produced for Quansight Labs is accessible, so please address the the following guidelines in your post.-->

## Text styling

- [ ] The blog is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags in order to do so (with only one level-one header).
- [ ] All links describe where they link to (for example, check the [Quansight labs website](https://labs.quansight.org/)).
- [ ] Any kind of styling that the author uses (for example, bold for emphasis) is consistent throughout the blog.

## Non-text contents

- [ ] All content is represented as text (for example, images need alt text and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing gifs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If it were to be read as plain text, the blog still makes sense and no information is missing.
