### PR TITLE
modify labs styling

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -807,7 +807,7 @@ IMAGE_THUMBNAIL_SIZE = 400
 # paraiso-light, pastie, perldoc, rrt, tango, trac, vim, vs, xcode
 # This list MAY be incomplete since pygments adds styles every now and then.
 # Check with list(pygments.styles.get_all_styles()) in an interpreter.
-CODE_COLOR_SCHEME = 'friendly'  # 'native' #'colorful'  #monokai'
+CODE_COLOR_SCHEME = 'dark2'  # 'native' #'colorful'  #monokai'
 
 # FAVICONS contains (name, file, size) tuples.
 # Used to create favicon link like this:

--- a/conf.py
+++ b/conf.py
@@ -807,7 +807,7 @@ IMAGE_THUMBNAIL_SIZE = 400
 # paraiso-light, pastie, perldoc, rrt, tango, trac, vim, vs, xcode
 # This list MAY be incomplete since pygments adds styles every now and then.
 # Check with list(pygments.styles.get_all_styles()) in an interpreter.
-CODE_COLOR_SCHEME = 'dark2'  # 'native' #'colorful'  #monokai'
+CODE_COLOR_SCHEME = 'vs'  # 'native' #'colorful'  #monokai'
 
 # FAVICONS contains (name, file, size) tuples.
 # Used to create favicon link like this:

--- a/conf.py
+++ b/conf.py
@@ -807,7 +807,7 @@ IMAGE_THUMBNAIL_SIZE = 400
 # paraiso-light, pastie, perldoc, rrt, tango, trac, vim, vs, xcode
 # This list MAY be incomplete since pygments adds styles every now and then.
 # Check with list(pygments.styles.get_all_styles()) in an interpreter.
-CODE_COLOR_SCHEME = 'vs'  # 'native' #'colorful'  #monokai'
+CODE_COLOR_SCHEME = 'friendly'  # 'native' #'colorful'  #monokai'
 
 # FAVICONS contains (name, file, size) tuples.
 # Used to create favicon link like this:

--- a/themes/quansightlabs/assets/css/custom.css
+++ b/themes/quansightlabs/assets/css/custom.css
@@ -6965,3 +6965,55 @@ div.input * {
     background-color: none;
 }
 
+
+/* custom */
+/* relative font sizes based on material design typography */
+h1,
+.h1 {
+  font-size: 4rem;
+}
+h2,
+.h2 {
+  font-size: 3rem;
+}
+h3,
+.h3 {
+  font-size: 2.5rem;
+}
+h4,
+.h4 {
+  font-size: 2.125rem;
+}
+h5,
+.h5 {
+  font-size: 1.5rem;
+}
+h6,
+.h6 {
+  font-size: 1.25rem;
+}
+/* make links visible, but remove this opinion in stylized conditions */
+a {
+  text-decoration: underline;
+}
+/* remove the underline from select link types */
+.nav-item a, .metadata a, a.tag, h2.entry-title a, h1.entry-title a {
+  text-decoration: none;
+}
+blockquote p {
+  font-size: 1rem;
+}
+
+html, body {
+  font-size: 16px;
+}
+
+.body-content {
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 90%;
+}
+
+.postindex {
+  max-width: 80%;
+}

--- a/themes/quansightlabs/assets/css/custom.css
+++ b/themes/quansightlabs/assets/css/custom.css
@@ -7010,10 +7010,18 @@ html, body {
 
 .body-content {
   margin-right: auto;
-  margin-left: auto;
+  margin-left: auto;  
   max-width: 90%;
 }
 
 .postindex {
   max-width: 80%;
+}
+
+.rendered_html :visited {
+  text-decoration: underline !important;
+}
+
+.rendered_html :link {
+  text-decoration: underline !important;
 }

--- a/themes/quansightlabs/templates/index.tmpl
+++ b/themes/quansightlabs/templates/index.tmpl
@@ -35,7 +35,7 @@
 % for post in posts:
     <article class="h-entry post-${post.meta('type')}" itemscope="itemscope" itemtype="http://schema.org/Article">
     <header>
-        <h1 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h1>
+        <h2 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h2>
         <div class="metadata">
             <p class="byline author vcard"><span class="byline-name fn" itemprop="author">
             % if author_pages_generated and multiple_authors_per_post:


### PR DESCRIPTION
this pull request will address a few outstanding issues. 

1. change the blog index to include a single h1 by replacing the blog posts with h2. this change is more compliant with WCAG.
2. style our link anchors to improve their visibility (resolve #110 )

  we resolve this by adding underlines that are recommended in the mdn docs. https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Styling_links

3. considerations on the pygments theme

@rgommers @trallard we'll need to choose a theme to rectify the syntax highlighting problem in #176 . could y'all pick a pygments theme from https://help.farbox.com/pygments.html that you think is preferable. it turns out contrast for pygments has been a problem for a while https://maxchadwick.xyz/blog/syntax-highlighting-and-color-contrast-accessibility

4. modifies the font-sizes to use the specification followed by material design. the base font size is raised from 14px to 16px as per material. the h1-h6 are then represented in the rem units used by materials design. this effort continues the work in #109 

  after all, i cranked down the relative units, but there is still a nice increase in font size.