### PR TITLE
Fix date on Jupyter CZI accessibility post

### DIFF
--- a/posts/2022/02/jupyter-czi-accessibility-roadmap-announcement.md
+++ b/posts/2022/02/jupyter-czi-accessibility-roadmap-announcement.md
@@ -1,7 +1,7 @@
 <!--
 .. title: Jupyter accessibility efforts have a roadmap!
 .. slug: jupyter-accessibility-efforts-have-a-roadmap
-.. date: 2022-02-29 10:00:00 UTC+00:00
+.. date: 2022-02-28 10:00:00 UTC+00:00
 .. author: Isabela Presedo-Floyd
 .. tags: Accessibility, JLabA11y, Jupyter, JupyterLab
 .. category:


### PR DESCRIPTION
I couldn't get the site to build locally, I was seeing an error for an invalid date - probably because this year we don't have Feb 29 :)