### PR TITLE
STY Better mobile spacing

### DIFF
--- a/themes/quansightlabs/assets/css/custom.css
+++ b/themes/quansightlabs/assets/css/custom.css
@@ -7008,16 +7008,6 @@ html, body {
   font-size: 16px;
 }
 
-.body-content {
-  margin-right: auto;
-  margin-left: auto;  
-  max-width: 90%;
-}
-
-.postindex {
-  max-width: 80%;
-}
-
 .rendered_html :visited {
   text-decoration: underline !important;
 }


### PR DESCRIPTION
This PR improves the style of the blog index for mobile (by removing some nested max-width in the CSS): 

## On `main`

![Screen Shot 2022-03-08 at 12 19 34 PM](https://user-images.githubusercontent.com/5402633/157291415-073db721-d269-43ac-88b8-1a940e1ef1c8.jpg)

## This PR

![Screen Shot 2022-03-08 at 12 19 47 PM](https://user-images.githubusercontent.com/5402633/157291446-4fbe57c7-e5db-4276-977a-d067a9918246.jpg)

