### PR TITLE
Fix 404 pages

### DIFF
--- a/plugins/errorpages/templates/jinja/404.tmpl
+++ b/plugins/errorpages/templates/jinja/404.tmpl
@@ -3,9 +3,9 @@
 
 {% block content %}
   <div class="title">
-    <h1 class="entry-title">{{ messages('Not Found', lang) }}</h1>
+    <h1 class="entry-title">Not Found</h1>
   </div>
   <div class="main entry-content">
-    {{ messages('The page you are trying to access does not exist. Please use your browser\'s "back" button to return to the previous page.', lang) }}
+    The page you are trying to access does not exist. Please use your browser's "back" button to return to the previous page.
   </div>
 {% endblock %}

--- a/plugins/errorpages/templates/mako/404.tmpl
+++ b/plugins/errorpages/templates/mako/404.tmpl
@@ -3,9 +3,9 @@
 
 <%block name="content">
   <div class="title">
-    <h1 class="entry-title">{{ messages('Not Found', lang) }}</h1>
+    <h1 class="entry-title">Not Found</h1>
   </div>
   <div class="main entry-content">
-    {{ messages('The page you are trying to access does not exist. Please use your browser\'s "back" button to return to the previous page.', lang) }}
+    The page you are trying to access does not exist. Please use your browser's "back" button to return to the previous page.
   </div>
 </%block>


### PR DESCRIPTION
Before this PR, the 404 page leaks the translation machinery, so you get a page with code in the h1 and div:

![](https://user-images.githubusercontent.com/317883/177719503-5e1a8d9a-c02e-445b-9b2f-60d024640e49.png)

After this PR, you get a normal looking 404 that says "Not Found":

![](https://user-images.githubusercontent.com/317883/177719822-abb6bccc-4f1b-498f-ac64-0dddfdb7d278.png)
